### PR TITLE
chore: use maven to build package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .idea
 
 # Build files
-classpath.txt
 target
 
 # Input

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 CLI to collect runtime context of a Java class.
 
-### Execution
+## Execution
 
+### Setup project for collecting runtime statistics
 1. Build classpath of the project you want to collect runtime information of.
     ```bash
    $ mvn dependency:build-classpath -Dmdep.outputFile=classpath.txt
@@ -19,11 +20,14 @@ CLI to collect runtime context of a Java class.
       $ javac -g -cp $(cat classpath.txt) @sources.txt -d target
       ```
       > NOTE: Test resources are not compiled as of now.
-3. Make an executable of "collector-sahab"
+
+### Build `collector-sahab`
+
+1. Package the app
     ```bash
-   $ ./build.sh
+   $ mvn package
     ```
-4. Prepare for execution of `collector sahab`.
+2. Prepare for execution of `collector sahab`.
    1. Create an `input` file containing a map of class names and breakpoints.
       Example:
       ```text
@@ -32,7 +36,7 @@ CLI to collect runtime context of a Java class.
       ```
    2. Run the process
       ```bash
-      $ java -cp target/:$(cat classpath.txt) se.kth.debug.Collector \
+      $ java -jar/target/debugger-1.0-SNAPSHOT-jar-with-dependencies.jar \
            -p </path/to/project>
            -t </path/to/project/test/directory>
            -i <path/to/input/file> (default="input.txt")

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/bash
-
-find src/main -name "*.java" > sources.txt
-
-javac -g -cp $(cat classpath.txt) @sources.txt -d target
-
-trap "rm sources.txt" EXIT

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,29 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>se.kth.debug.Collector</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id><!-- this is used for inheritance merges -->
+                        <phase>package</phase><!-- append to the packaging phase. -->
+                        <goals>
+                            <goal>single</goal><!-- goals == mojos -->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>2.21.0</version>


### PR DESCRIPTION
Now we use maven to build the package as we do not need `-g` for the compilation of `collector-sahab`.