### PR TITLE
feat: skip collection of non-static fields of classes from static method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
                     <includes>
                         <include>CollectorTest.java</include>
                         <include>UtilityTest.java</include>
+                        <include>CollectorAPITest.java</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/src/main/java/se/kth/debug/Collector.java
+++ b/src/main/java/se/kth/debug/Collector.java
@@ -72,9 +72,36 @@ public class Collector implements Callable<Integer> {
     @Override
     public Integer call() throws IOException, AbsentInformationException {
         EventProcessor eventProcessor =
+                invoke(
+                        providedClasspath,
+                        tests,
+                        classesAndBreakpoints,
+                        objectDepth,
+                        stackTraceDepth,
+                        numberOfArrayElements,
+                        skipPrintingField);
+        write(eventProcessor);
+        return 0;
+    }
+
+    public static EventProcessor invoke(
+            String[] providedClasspath,
+            String[] tests,
+            File classesAndBreakpoints,
+            int objectDepth,
+            int stackTraceDepth,
+            int numberOfArrayElements,
+            boolean skipPrintingField)
+            throws AbsentInformationException {
+        EventProcessor eventProcessor =
                 new EventProcessor(providedClasspath, tests, classesAndBreakpoints);
         eventProcessor.startEventProcessor(
                 objectDepth, stackTraceDepth, numberOfArrayElements, skipPrintingField);
+
+        return eventProcessor;
+    }
+
+    public static void write(EventProcessor eventProcessor) throws IOException {
         if (!eventProcessor.getBreakpointContexts().isEmpty()) {
             writeBreakpointsToFile(eventProcessor.getBreakpointContexts());
             logger.info("Output file generated!");
@@ -87,7 +114,6 @@ public class Collector implements Callable<Integer> {
         } else {
             logger.info("No method exits were encountered.");
         }
-        return 0;
     }
 
     private static void writeBreakpointsToFile(List<BreakPointContext> breakPointContext)

--- a/src/main/java/se/kth/debug/Debugger.java
+++ b/src/main/java/se/kth/debug/Debugger.java
@@ -276,13 +276,11 @@ public class Debugger {
             Value value;
             if (field.isStatic()) {
                 value = stackFrame.location().declaringType().getValue(field);
-            } else if (stackFrame.location().declaringType().isStatic()) {
-                logger.warning(
-                        "Cannot get fields of static inner classes: "
-                                + field.declaringType().name()
-                                + ":"
-                                + field.name());
-                value = null;
+            } else if (stackFrame.location().method().isStatic()) {
+                // Since we are inside a static method, we don't have access to the non-static
+                // field.
+                // Hence, we are skipping its collection.
+                continue;
             } else {
                 value = stackFrame.thisObject().getValue(field);
             }

--- a/src/main/java/se/kth/debug/struct/result/BreakPointContext.java
+++ b/src/main/java/se/kth/debug/struct/result/BreakPointContext.java
@@ -13,4 +13,12 @@ public class BreakPointContext {
         this.lineNumber = lineNumber;
         this.stackFrameContexts = stackFrameContexts;
     }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public List<StackFrameContext> getStackFrameContexts() {
+        return stackFrameContexts;
+    }
 }

--- a/src/main/java/se/kth/debug/struct/result/StackFrameContext.java
+++ b/src/main/java/se/kth/debug/struct/result/StackFrameContext.java
@@ -23,4 +23,8 @@ public class StackFrameContext {
     public void addRuntimeValueCollection(List<? extends RuntimeValue> runtimeValues) {
         this.runtimeValueCollection.addAll(runtimeValues);
     }
+
+    public List<RuntimeValue> getRuntimeValueCollection() {
+        return runtimeValueCollection;
+    }
 }

--- a/src/test/java/CollectorAPITest.java
+++ b/src/test/java/CollectorAPITest.java
@@ -1,0 +1,38 @@
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+
+import com.sun.jdi.AbsentInformationException;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import se.kth.debug.Collector;
+import se.kth.debug.EventProcessor;
+import se.kth.debug.struct.result.BreakPointContext;
+import se.kth.debug.struct.result.StackFrameContext;
+
+public class CollectorAPITest {
+    @Test
+    void invoke_nonStaticFieldsOfStaticClassesShouldNotBeCollected()
+            throws AbsentInformationException {
+        // arrange
+        String[] classpath =
+                TestHelper.getMavenClasspathFromBuildDirectory(
+                        TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("with-debug"));
+        String[] tests = new String[] {"foo.StaticClassFieldTest::test_doSomething"};
+        File classesAndBreakpoints =
+                new File("src/test/resources/sample-maven-project/static-class-field.txt");
+
+        // act
+        EventProcessor eventProcessor =
+                Collector.invoke(classpath, tests, classesAndBreakpoints, 0, 1, 10, false);
+        BreakPointContext bp =
+                eventProcessor.getBreakpointContexts().stream()
+                        .filter(bpc -> bpc.getLineNumber() == 24)
+                        .findAny()
+                        .get();
+        StackFrameContext sf = bp.getStackFrameContexts().get(0);
+
+        // assert
+        assertThat(sf.getRuntimeValueCollection(), is(empty()));
+    }
+}

--- a/src/test/java/CollectorAPITest.java
+++ b/src/test/java/CollectorAPITest.java
@@ -29,7 +29,7 @@ public class CollectorAPITest {
                 eventProcessor.getBreakpointContexts().stream()
                         .filter(bpc -> bpc.getLineNumber() == 24)
                         .findAny()
-                        .get();
+                        .orElseThrow();
         StackFrameContext sf = bp.getStackFrameContexts().get(0);
 
         // assert

--- a/src/test/java/CollectorTest.java
+++ b/src/test/java/CollectorTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Path;
 import java.security.Permission;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -63,14 +64,14 @@ public class CollectorTest {
         // arrange
         Path breakpointJson = tempDir.resolve("output.json");
         Path returnValueJson = tempDir.resolve("return.json");
-        String classpath =
+        String[] classpath =
                 TestHelper.getMavenClasspathFromBuildDirectory(
                         TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("with-debug"));
         String[] args = {
             "-i",
             TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("input.txt").toString(),
             "-p",
-            classpath,
+            StringUtils.join(classpath, " "),
             "-t",
             "foo.BasicMathTest::test_add foo.BasicMathTest::test_subtract",
             "-b",
@@ -99,14 +100,14 @@ public class CollectorTest {
         // arrange
         Path breakpointJson = tempDir.resolve("output.json");
         Path returnValueJson = tempDir.resolve("return.json");
-        String classpath =
+        String[] classpath =
                 TestHelper.getMavenClasspathFromBuildDirectory(
                         TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("without-debug"));
         String[] args = {
             "-i",
             TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("input.txt").toString(),
             "-p",
-            classpath,
+            StringUtils.join(classpath, " "),
             "-t",
             "foo.BasicMathTest::test_add foo.BasicMathTest::test_subtract",
             "-b",

--- a/src/test/java/TestHelper.java
+++ b/src/test/java/TestHelper.java
@@ -1,18 +1,17 @@
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 
 public class TestHelper {
     public static final Path PATH_TO_SAMPLE_MAVEN_PROJECT =
             Paths.get("src/test/resources/sample-maven-project");
 
-    public static String getMavenClasspathFromBuildDirectory(Path buildDirectory) {
+    public static String[] getMavenClasspathFromBuildDirectory(Path buildDirectory) {
         List<String> classpath =
                 List.of(
                         buildDirectory.resolve("classes").toString(),
                         buildDirectory.resolve("test-classes").toString(),
                         buildDirectory.resolve("dependency").toString());
-        return StringUtils.join(classpath, " ");
+        return classpath.toArray(new String[] {});
     }
 }

--- a/src/test/resources/sample-maven-project/src/main/java/foo/StaticClassField.java
+++ b/src/test/resources/sample-maven-project/src/main/java/foo/StaticClassField.java
@@ -1,0 +1,27 @@
+package foo;
+
+public class StaticClassField {
+    public boolean doSomething() {
+        Pair p = Pair.createPair(1, 2);
+        p.sayHelloWorld();
+        return true;
+    }
+
+    static class Pair {
+        private int a;
+        private int b;
+
+        public static Pair createPair(int a, int b) {
+            return new Pair(a, b);
+        }
+
+        private Pair(int a, int b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        private static void sayHelloWorld() {
+            System.out.println("hello world");
+        }
+    }
+}

--- a/src/test/resources/sample-maven-project/src/test/java/foo/StaticClassFieldTest.java
+++ b/src/test/resources/sample-maven-project/src/test/java/foo/StaticClassFieldTest.java
@@ -1,0 +1,13 @@
+package foo;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import foo.StaticClassField;
+
+public class StaticClassFieldTest {
+    @Test
+    void test_doSomething() {
+        assertTrue(new StaticClassField().doSomething());
+    }
+}

--- a/src/test/resources/sample-maven-project/static-class-field.txt
+++ b/src/test/resources/sample-maven-project/static-class-field.txt
@@ -1,0 +1,1 @@
+foo.StaticClassField$Pair=15,24


### PR DESCRIPTION
Fixes https://github.com/algomaster99/collector-sahab/issues/24

We cannot collect non-static fields of a class when we are inside a static method because we don't have access to the object reference. However, you will get its value when you set the `stack-frame-depth` such that the frame has access to the object reference.