### PR TITLE
feat: decouple breakpoint and return data collection

### DIFF
--- a/scripts/bribe-sahab.py
+++ b/scripts/bribe-sahab.py
@@ -68,6 +68,7 @@ def _run_collector_sahab(project, tests, revision, ref):
     f"-t {test_methods} "
     f"-b {breakpoint_output} "
     f"-r {return_output} "
+    "-m method-name.txt "
     f"--object-depth=0"
   )
 

--- a/src/main/java/se/kth/debug/Collector.java
+++ b/src/main/java/se/kth/debug/Collector.java
@@ -36,11 +36,11 @@ public class Collector implements Callable<Integer> {
             description = "File containing all return values of methods in the provided class.")
     private static String returnValueJson;
 
-    @CommandLine.Option(
-            names = "-i",
-            description = "File containing class names and breakpoints",
-            defaultValue = "input.txt")
-    private File classesAndBreakpoints;
+    @CommandLine.Option(names = "-i", description = "File containing class names and breakpoints")
+    private static File classesAndBreakpoints = null;
+
+    @CommandLine.Option(names = "-ir", description = "File containing method names")
+    private static File methodNames = null;
 
     @CommandLine.Option(
             names = "--object-depth",
@@ -78,7 +78,7 @@ public class Collector implements Callable<Integer> {
     public Integer call() throws IOException, AbsentInformationException {
         CollectorOptions context = getCollectorOptions();
         EventProcessor eventProcessor =
-                invoke(providedClasspath, tests, classesAndBreakpoints, context);
+                invoke(providedClasspath, tests, classesAndBreakpoints, methodNames, context);
         write(eventProcessor);
         return 0;
     }
@@ -87,10 +87,11 @@ public class Collector implements Callable<Integer> {
             String[] providedClasspath,
             String[] tests,
             File classesAndBreakpoints,
+            File methodNames,
             CollectorOptions context)
             throws AbsentInformationException {
         EventProcessor eventProcessor =
-                new EventProcessor(providedClasspath, tests, classesAndBreakpoints);
+                new EventProcessor(providedClasspath, tests, classesAndBreakpoints, methodNames);
         eventProcessor.startEventProcessor(context);
 
         return eventProcessor;
@@ -114,7 +115,10 @@ public class Collector implements Callable<Integer> {
         } else {
             logger.info("Output file was not generated as breakpoints were not visited.");
         }
-        if (!eventProcessor.getReturnValues().isEmpty()) {
+        if (methodNames == null) {
+            logger.info(
+                    "Return data was not asked for. Please provide method names if you desire otherwise.");
+        } else if (!eventProcessor.getReturnValues().isEmpty()) {
             writeReturnValuesToFile(eventProcessor.getReturnValues());
             logger.info("Return values are output to the file!");
         } else {

--- a/src/main/java/se/kth/debug/EventProcessor.java
+++ b/src/main/java/se/kth/debug/EventProcessor.java
@@ -1,5 +1,7 @@
 package se.kth.debug;
 
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;
 import java.io.*;
@@ -9,6 +11,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import se.kth.debug.struct.FileAndBreakpoint;
+import se.kth.debug.struct.MethodForExitEvent;
 import se.kth.debug.struct.result.BreakPointContext;
 import se.kth.debug.struct.result.ReturnData;
 import se.kth.debug.struct.result.StackFrameContext;
@@ -21,7 +24,6 @@ public class EventProcessor {
     private final List<BreakPointContext> breakpointContexts = new ArrayList<>();
     private final List<ReturnData> returnValues = new ArrayList<>();
     private final Debugger debugger;
-    private String methodName = null;
 
     private boolean shouldRecordBreakpointData = false;
     private boolean shouldRecordReturnData = false;
@@ -30,12 +32,16 @@ public class EventProcessor {
             String[] providedClasspath,
             String[] tests,
             File classesAndBreakpoints,
-            File methodNames) {
+            File methodsForExitEvent) {
+        parseMethodsForExitEvent(methodsForExitEvent);
+        shouldRecordBreakpointData = classesAndBreakpoints != null;
+        shouldRecordReturnData = methodsForExitEvent != null;
         debugger =
                 new Debugger(
-                        providedClasspath, tests, parseFileAndBreakpoints(classesAndBreakpoints));
-        shouldRecordBreakpointData = classesAndBreakpoints != null;
-        shouldRecordReturnData = methodNames != null;
+                        providedClasspath,
+                        tests,
+                        parseFileAndBreakpoints(classesAndBreakpoints),
+                        parseMethodsForExitEvent(methodsForExitEvent));
     }
 
     /** Monitor events triggered by JDB. */
@@ -59,7 +65,6 @@ public class EventProcessor {
                         }
                     }
                     if (event instanceof BreakpointEvent) {
-                        methodName = ((BreakpointEvent) event).location().method().name();
                         List<StackFrameContext> result =
                                 debugger.processBreakpoints((BreakpointEvent) event, context);
                         Location location = ((BreakpointEvent) event).location();
@@ -68,9 +73,11 @@ public class EventProcessor {
                                         location.sourcePath(), location.lineNumber(), result));
                     }
                     if (event instanceof MethodExitEvent) {
-                        if (((MethodExitEvent) event).method().name().equals(methodName))
-                            returnValues.add(
-                                    debugger.processMethodExit((MethodExitEvent) event, context));
+                        ReturnData rd =
+                                debugger.processMethodExit((MethodExitEvent) event, context);
+                        if (rd != null) {
+                            returnValues.add(rd);
+                        }
                     }
                 }
                 vm.resume();
@@ -84,6 +91,9 @@ public class EventProcessor {
     }
 
     private List<FileAndBreakpoint> parseFileAndBreakpoints(File classesAndBreakpoints) {
+        if (classesAndBreakpoints == null) {
+            return null;
+        }
         try (BufferedReader br = new BufferedReader(new FileReader(classesAndBreakpoints))) {
             List<FileAndBreakpoint> parsedFileAndBreakpoints = new ArrayList<>();
             for (String line; (line = br.readLine()) != null; ) {
@@ -98,6 +108,18 @@ public class EventProcessor {
                 parsedFileAndBreakpoints.add(fNB);
             }
             return parsedFileAndBreakpoints;
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    private MethodForExitEvent parseMethodsForExitEvent(File methodsForExitEvent) {
+        if (methodsForExitEvent == null) {
+            return null;
+        }
+        try (JsonReader jr = new JsonReader(new FileReader(methodsForExitEvent))) {
+            Gson gson = new Gson();
+            return gson.fromJson(jr, MethodForExitEvent.class);
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage());
         }

--- a/src/main/java/se/kth/debug/MatchedLineFinder.java
+++ b/src/main/java/se/kth/debug/MatchedLineFinder.java
@@ -1,5 +1,8 @@
 package se.kth.debug;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import gumtree.spoon.AstComparator;
 import gumtree.spoon.diff.Diff;
 import gumtree.spoon.diff.operations.Operation;
@@ -39,6 +42,7 @@ public class MatchedLineFinder {
         CtMethod<?> methodLeft = findMethod(diff.getRootOperations());
         CtMethod<?> methodRight =
                 (CtMethod<?>) new SpoonSupport().getMappedElement(diff, methodLeft, true);
+        writeMethodName(methodLeft);
         Set<Integer> matchedLinesLeft = getMatchedLines(diffLines, methodLeft);
         Set<Integer> matchedLinesRight = getMatchedLines(diffLines, methodRight);
         String fullyQualifiedNameOfContainerClass =
@@ -56,6 +60,15 @@ public class MatchedLineFinder {
                         StringUtils.join(matchedLinesRight, ","));
         writeToFile(outputLeft, "input-left.txt");
         writeToFile(outputRight, "input-right.txt");
+    }
+
+    private static void writeMethodName(CtMethod<?> method) throws IOException {
+        final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonObject object = new JsonObject();
+        object.addProperty("name", method.getSimpleName());
+        object.addProperty("signature", method.getSignature());
+        object.addProperty("className", method.getDeclaringType().getQualifiedName());
+        writeToFile(gson.toJson(object), "method-name.txt");
     }
 
     private static Set<Integer> getDiffLines(List<Operation> rootOperations) {

--- a/src/main/java/se/kth/debug/struct/MethodForExitEvent.java
+++ b/src/main/java/se/kth/debug/struct/MethodForExitEvent.java
@@ -1,0 +1,25 @@
+package se.kth.debug.struct;
+
+public class MethodForExitEvent {
+    private final String name;
+    private final String signature;
+    private final String className;
+
+    public MethodForExitEvent(String name, String signature, String className) {
+        this.name = name;
+        this.signature = signature;
+        this.className = className;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/src/main/java/se/kth/debug/struct/result/ReturnData.java
+++ b/src/main/java/se/kth/debug/struct/result/ReturnData.java
@@ -5,10 +5,10 @@ import java.util.List;
 public class ReturnData implements RuntimeValue {
     private final RuntimeValueKind kind = RuntimeValueKind.RETURN;
     private final String methodName;
+    private final List<String> stackTrace;
     private final ValueWrapper value;
     private final String location;
     private final List<LocalVariableData> arguments;
-    private final List<String> stackTrace;
     private List<FieldData> fields = null;
 
     public ReturnData(

--- a/src/test/java/CollectorAPITest.java
+++ b/src/test/java/CollectorAPITest.java
@@ -30,7 +30,11 @@ public class CollectorAPITest {
         // act
         EventProcessor eventProcessor =
                 Collector.invoke(
-                        classpath, tests, classesAndBreakpoints, TestHelper.getDefaultOptions());
+                        classpath,
+                        tests,
+                        classesAndBreakpoints,
+                        null,
+                        TestHelper.getDefaultOptions());
         BreakPointContext bp =
                 eventProcessor.getBreakpointContexts().stream()
                         .filter(bpc -> bpc.getLineNumber() == 24)
@@ -68,7 +72,11 @@ public class CollectorAPITest {
             // act
             EventProcessor eventProcessor =
                     Collector.invoke(
-                            classpath, tests, classesAndBreakpoints, setObjectAndArrayDepth(1, 0));
+                            classpath,
+                            tests,
+                            classesAndBreakpoints,
+                            null,
+                            setObjectAndArrayDepth(1, 0));
 
             BreakPointContext breakpoint = eventProcessor.getBreakpointContexts().get(0);
             StackFrameContext stackFrameContext = breakpoint.getStackFrameContexts().get(0);
@@ -122,6 +130,7 @@ public class CollectorAPITest {
                             classpath,
                             tests,
                             classesAndBreakpoints,
+                            null,
                             TestHelper.getDefaultOptions());
 
             BreakPointContext breakpoint = eventProcessor.getBreakpointContexts().get(0);
@@ -156,6 +165,7 @@ public class CollectorAPITest {
                                 classpath,
                                 tests,
                                 classesAndBreakpoints,
+                                null,
                                 setObjectAndArrayDepth(1, arrayDepth));
                 return eventProcessor.getBreakpointContexts().get(0).getStackFrameContexts().get(0);
             }


### PR DESCRIPTION
Fixes #29 

Another option `-m` has been added which allows one to set which method's exit has to be recorded. We compare methods using their name so if there are overloaded methods, one will get returns for all those methods. I am not using signatures to compare them because Spoon's signature and JDI's signature were a bit different. 