### PR TITLE
fix: handle all primitive values

### DIFF
--- a/src/main/java/se/kth/debug/Debugger.java
+++ b/src/main/java/se/kth/debug/Debugger.java
@@ -278,6 +278,8 @@ public class Debugger {
             return ((LongValue) value).value();
         } else if (value instanceof CharValue) {
             return ((CharValue) value).value();
+        } else if (value instanceof ByteValue) {
+            return ((ByteValue) value).value();
         } else if (isPrimitiveWrapper(value)) {
             Field field = ((ObjectReference) value).referenceType().fieldByName("value");
             Value nestedValue = ((ObjectReference) value).getValue(field);

--- a/src/main/java/se/kth/debug/Debugger.java
+++ b/src/main/java/se/kth/debug/Debugger.java
@@ -280,6 +280,8 @@ public class Debugger {
             return ((CharValue) value).value();
         } else if (value instanceof ByteValue) {
             return ((ByteValue) value).value();
+        } else if (value instanceof DoubleValue) {
+            return ((DoubleValue) value).value();
         } else if (isPrimitiveWrapper(value)) {
             Field field = ((ObjectReference) value).referenceType().fieldByName("value");
             Value nestedValue = ((ObjectReference) value).getValue(field);


### PR DESCRIPTION
We get the following: `java.lang.ClassCastException: class com.sun.tools.jdi.ByteValueImpl cannot be cast to class com.sun.jdi.ObjectReference` for https://github.com/khaes-kth/drr-execdiff/commit/75093e2c7b15373ef75dfeb8ab2e9ce16562fce5. This PR proposes fix for the same.