### PR TITLE
refactor: store breakpoint in json format

### DIFF
--- a/src/main/java/se/kth/debug/EventProcessor.java
+++ b/src/main/java/se/kth/debug/EventProcessor.java
@@ -1,15 +1,14 @@
 package se.kth.debug;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;
 import java.io.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import se.kth.debug.struct.FileAndBreakpoint;
 import se.kth.debug.struct.MethodForExitEvent;
 import se.kth.debug.struct.result.BreakPointContext;
@@ -94,20 +93,9 @@ public class EventProcessor {
         if (classesAndBreakpoints == null) {
             return null;
         }
-        try (BufferedReader br = new BufferedReader(new FileReader(classesAndBreakpoints))) {
-            List<FileAndBreakpoint> parsedFileAndBreakpoints = new ArrayList<>();
-            for (String line; (line = br.readLine()) != null; ) {
-                String[] fileAndBreakpoints = line.split("=");
-                String[] breakpoints = fileAndBreakpoints[1].split(",");
-                List<Integer> parsedBreakpoints =
-                        Arrays.stream(breakpoints)
-                                .map(Integer::parseInt)
-                                .collect(Collectors.toList());
-                FileAndBreakpoint fNB =
-                        new FileAndBreakpoint(fileAndBreakpoints[0], parsedBreakpoints);
-                parsedFileAndBreakpoints.add(fNB);
-            }
-            return parsedFileAndBreakpoints;
+        try (JsonReader jr = new JsonReader(new FileReader(classesAndBreakpoints))) {
+            Gson gson = new Gson();
+            return gson.fromJson(jr, new TypeToken<List<FileAndBreakpoint>>() {}.getType());
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage());
         }

--- a/src/test/java/CollectorTest.java
+++ b/src/test/java/CollectorTest.java
@@ -221,4 +221,33 @@ public class CollectorTest {
             }
         }
     }
+
+    @Test
+    void shouldNotFailEvenIfZeroBreakpointsAreProvided(@TempDir Path tempDir) throws IOException {
+        // arrange
+        Path outputJson = tempDir.resolve("output.json");
+        String[] classpath =
+                TestHelper.getMavenClasspathFromBuildDirectory(
+                        TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("with-debug"));
+        String[] args = {
+            "-i",
+            TestHelper.PATH_TO_BREAKPOINT_INPUT.resolve("zero-breakpoints-basic-math.txt").toString(),
+            "-p",
+            StringUtils.join(classpath, " "),
+            "-t",
+            "foo.BasicMathTest::test_add",
+            "-o",
+            outputJson.toString()
+        };
+
+        // act
+        assertThrows(ExitException.class, () -> Collector.main(args));
+
+        // assert
+        try (JsonReader jsonReader = new JsonReader(new FileReader(outputJson.toFile()))) {
+            final Gson gson = new Gson();
+            Object json = gson.fromJson(jsonReader, Object.class);
+            assertThat(((LinkedTreeMap<?, ?>) json).size(), equalTo(0));
+        }
+    }
 }

--- a/src/test/java/CollectorTest.java
+++ b/src/test/java/CollectorTest.java
@@ -231,7 +231,9 @@ public class CollectorTest {
                         TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("with-debug"));
         String[] args = {
             "-i",
-            TestHelper.PATH_TO_BREAKPOINT_INPUT.resolve("zero-breakpoints-basic-math.txt").toString(),
+            TestHelper.PATH_TO_BREAKPOINT_INPUT
+                    .resolve("zero-breakpoints-basic-math.txt")
+                    .toString(),
             "-p",
             StringUtils.join(classpath, " "),
             "-t",

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/basic-math.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/basic-math.txt
@@ -1,1 +1,6 @@
-foo.BasicMath=5,9
+[
+    {
+        "fileName": "foo.BasicMath",
+        "breakpoints": [5,9]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/collections/nested-array.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/collections/nested-array.txt
@@ -1,1 +1,6 @@
-foo.collections.NestedArray=7
+[
+    {
+        "fileName": "foo.collections.NestedArray",
+        "breakpoints": [7]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/collections/nested-collection.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/collections/nested-collection.txt
@@ -1,1 +1,6 @@
-foo.collections.NestedCollection=11
+[
+    {
+        "fileName": "foo.collections.NestedCollection",
+        "breakpoints": [11]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/collections/one-level.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/collections/one-level.txt
@@ -1,1 +1,6 @@
-foo.collections.OneLevelCollections=12
+[
+    {
+        "fileName": "foo.collections.OneLevelCollections",
+        "breakpoints": [12]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/collections/primitive.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/collections/primitive.txt
@@ -1,1 +1,6 @@
-foo.collections.Primitive=6
+[
+    {
+        "fileName": "foo.collections.Primitive",
+        "breakpoints": [6]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/multiple-level-nested-object.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/multiple-level-nested-object.txt
@@ -1,1 +1,6 @@
-foo.objects.MultipleLevelNestedObject=6
+[
+    {
+        "fileName": "foo.objects.MultipleLevelNestedObject",
+        "breakpoints": [6]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/static-class-field.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/static-class-field.txt
@@ -1,1 +1,6 @@
-foo.StaticClassField$Pair=15,24
+[
+    {
+        "fileName": "foo.StaticClassField$Pair",
+        "breakpoints": [15,24]
+    }
+]

--- a/src/test/resources/sample-maven-project/inputs/breakpoint/zero-breakpoints-basic-math.txt
+++ b/src/test/resources/sample-maven-project/inputs/breakpoint/zero-breakpoints-basic-math.txt
@@ -1,0 +1,6 @@
+[
+    {
+        "fileName": "foo.BasicMath",
+        "breakpoints": []
+    }
+]


### PR DESCRIPTION
Parsing an input file using the split function is more prone to errors like @khaes-kth observed in https://github.com/khaes-kth/drr-execdiff/commit/8cb7bce5e111d8ae82b9314b7a1fb53914357a56. Thus, the fix stores the breakpoints in a JSON format.