### PR TITLE
chore: remove subprocess instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,12 +138,5 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-<!--        This dependency is used for instrumenting subprocesses for coverage report. -->
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/JUnitTestRunnerTest.java
+++ b/src/test/java/JUnitTestRunnerTest.java
@@ -1,7 +1,6 @@
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,19 +27,9 @@ class JUnitTestRunnerTest {
                                 TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT_WITHOUT_DEBUG_INFO.resolve(
                                         "without-debug")));
 
-        File jaCoCoJavaagentJar = Utility.getJaCoCoJavaagentJar();
-        String jaCoCoJavaagentArgument =
-                String.format(
-                        "-javaagent:%s=destfile=target/jacoco.exec",
-                        jaCoCoJavaagentJar.getAbsolutePath());
         ProcessBuilder processBuilder =
                 new ProcessBuilder(
-                        "java",
-                        jaCoCoJavaagentArgument,
-                        "-cp",
-                        classpath,
-                        JUnitTestRunner.class.getCanonicalName(),
-                        tests);
+                        "java", "-cp", classpath, JUnitTestRunner.class.getCanonicalName(), tests);
         processBuilder.redirectOutput(actualLog.toFile());
 
         Process p = processBuilder.start();

--- a/src/test/java/UtilityTest.java
+++ b/src/test/java/UtilityTest.java
@@ -1,5 +1,6 @@
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,5 +39,10 @@ public class UtilityTest {
         assertThat(
                 Arrays.asList(actualClasspath.split(File.pathSeparator)),
                 hasItems(expectedClasspath.split(File.pathSeparator)));
+    }
+
+    @Test
+    void getJaCoCoJavaagentJar_throws_ClassNotFoundException() {
+        assertThrowsExactly(ClassNotFoundException.class, Utility::getJaCoCoJavaagentJar);
     }
 }


### PR DESCRIPTION
The strangest thing is happening when I try to instrument subprocess using JaCoCo. JaCoCo's dependency is interfering with other tests, and hence they all are failing on local. However, everything is in order on GitHub CI. To remove this duplicitous behaviour, I am reverting this change.