### PR TITLE
feat: pass methods explicitly to record their return values

### DIFF
--- a/scripts/bribe-sahab.py
+++ b/scripts/bribe-sahab.py
@@ -66,7 +66,7 @@ def _run_collector_sahab(project, tests, revision, ref):
     f"-p {' '.join(project_dependencies)} "
     f"-t {test_methods} "
     f"-o {collector_sahab_output} "
-    "--execution-depth 1"
+    f"-m methods.json"
   )
 
   subprocess.run(cmd, shell=True)

--- a/src/main/java/se/kth/debug/Collector.java
+++ b/src/main/java/se/kth/debug/Collector.java
@@ -108,6 +108,15 @@ public class Collector implements Callable<Integer> {
         return eventProcessor;
     }
 
+    public static EventProcessor invoke(
+            String[] providedClasspath,
+            String[] tests,
+            File classesAndBreakpoints,
+            CollectorOptions context)
+            throws AbsentInformationException {
+        return invoke(providedClasspath, tests, classesAndBreakpoints, null, context);
+    }
+
     private CollectorOptions getCollectorOptions() {
         CollectorOptions context = new CollectorOptions();
         context.setStackTraceDepth(stackTraceDepth);

--- a/src/main/java/se/kth/debug/Collector.java
+++ b/src/main/java/se/kth/debug/Collector.java
@@ -40,6 +40,9 @@ public class Collector implements Callable<Integer> {
             required = true)
     private File classesAndBreakpoints = null;
 
+    @CommandLine.Option(names = "-m", description = "File containing method names")
+    private File methodsForExitEvent = null;
+
     @CommandLine.Option(
             names = "--stack-trace-depth",
             description =
@@ -80,7 +83,12 @@ public class Collector implements Callable<Integer> {
     public Integer call() throws IOException, AbsentInformationException {
         CollectorOptions context = getCollectorOptions();
         EventProcessor eventProcessor =
-                invoke(providedClasspath, tests, classesAndBreakpoints, context);
+                invoke(
+                        providedClasspath,
+                        tests,
+                        classesAndBreakpoints,
+                        methodsForExitEvent,
+                        context);
         write(eventProcessor);
         return 0;
     }
@@ -89,10 +97,12 @@ public class Collector implements Callable<Integer> {
             String[] providedClasspath,
             String[] tests,
             File classesAndBreakpoints,
+            File methodsForExitEvent,
             CollectorOptions context)
             throws AbsentInformationException {
         EventProcessor eventProcessor =
-                new EventProcessor(providedClasspath, tests, classesAndBreakpoints);
+                new EventProcessor(
+                        providedClasspath, tests, classesAndBreakpoints, methodsForExitEvent);
         eventProcessor.startEventProcessor(context);
 
         return eventProcessor;

--- a/src/main/java/se/kth/debug/Debugger.java
+++ b/src/main/java/se/kth/debug/Debugger.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import se.kth.debug.struct.FileAndBreakpoint;
+import se.kth.debug.struct.MethodForExitEvent;
 import se.kth.debug.struct.result.*;
 
 public class Debugger {
@@ -23,14 +24,17 @@ public class Debugger {
     private final String[] pathToBuiltProject;
     private final String[] tests;
     private final List<FileAndBreakpoint> classesAndBreakpoints;
+    private final List<MethodForExitEvent> methodForExitEvents;
 
     public Debugger(
             String[] pathToBuiltProject,
             String[] tests,
-            List<FileAndBreakpoint> classesAndBreakpoints) {
+            List<FileAndBreakpoint> classesAndBreakpoints,
+            List<MethodForExitEvent> methodForExitEvents) {
         this.pathToBuiltProject = pathToBuiltProject;
         this.tests = tests;
         this.classesAndBreakpoints = classesAndBreakpoints;
+        this.methodForExitEvents = methodForExitEvents;
     }
 
     public VirtualMachine launchVMAndJunit() {
@@ -101,6 +105,11 @@ public class Debugger {
         if (classesAndBreakpoints != null) {
             for (FileAndBreakpoint classToBeDebugged : classesAndBreakpoints) {
                 classesFromRegisteringClassPrepareRequest.add(classToBeDebugged.getFileName());
+            }
+        }
+        if (methodForExitEvents != null) {
+            for (MethodForExitEvent method : methodForExitEvents) {
+                classesFromRegisteringClassPrepareRequest.add(method.getClassName());
             }
         }
         return classesFromRegisteringClassPrepareRequest;

--- a/src/main/java/se/kth/debug/Debugger.java
+++ b/src/main/java/se/kth/debug/Debugger.java
@@ -214,7 +214,8 @@ public class Debugger {
             throws IncompatibleThreadStateException, AbsentInformationException {
         String methodName = mee.method().name();
         if (!isReturnWithinBreakpoints(
-                mee.location().lineNumber(), mee.method().declaringType().name())) {
+                        mee.location().lineNumber(), mee.method().declaringType().name())
+                && !isMethodExplicitlyAskedFor(mee.method())) {
             return null;
         }
         String location = mee.location().toString();
@@ -254,6 +255,16 @@ public class Debugger {
                     continue;
                 }
                 return fNB.getBreakpoints().contains(lineNumber);
+            }
+        }
+        return false;
+    }
+
+    private boolean isMethodExplicitlyAskedFor(Method method) {
+        for (MethodForExitEvent candidate : methodForExitEvents) {
+            if (candidate.getName().equals(method.name())
+                    && candidate.getClassName().equals(method.declaringType().name())) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/se/kth/debug/EventProcessor.java
+++ b/src/main/java/se/kth/debug/EventProcessor.java
@@ -97,7 +97,7 @@ public class EventProcessor {
 
     private List<MethodForExitEvent> parseMethodsForExitEvent(File methodsForExitEvent) {
         if (methodsForExitEvent == null) {
-            return null;
+            return List.of();
         }
         try (JsonReader jr = new JsonReader(new FileReader(methodsForExitEvent))) {
             Gson gson = new Gson();

--- a/src/main/java/se/kth/debug/EventProcessor.java
+++ b/src/main/java/se/kth/debug/EventProcessor.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import se.kth.debug.struct.FileAndBreakpoint;
+import se.kth.debug.struct.MethodForExitEvent;
 import se.kth.debug.struct.result.BreakPointContext;
 import se.kth.debug.struct.result.ReturnData;
 import se.kth.debug.struct.result.StackFrameContext;
@@ -23,10 +24,17 @@ public class EventProcessor {
     private final List<ReturnData> returnValues = new ArrayList<>();
     private final Debugger debugger;
 
-    EventProcessor(String[] providedClasspath, String[] tests, File classesAndBreakpoints) {
+    EventProcessor(
+            String[] providedClasspath,
+            String[] tests,
+            File classesAndBreakpoints,
+            File methodsForExitEvent) {
         debugger =
                 new Debugger(
-                        providedClasspath, tests, parseFileAndBreakpoints(classesAndBreakpoints));
+                        providedClasspath,
+                        tests,
+                        parseFileAndBreakpoints(classesAndBreakpoints),
+                        parseMethodsForExitEvent(methodsForExitEvent));
     }
 
     /** Monitor events triggered by JDB. */
@@ -82,6 +90,18 @@ public class EventProcessor {
         try (JsonReader jr = new JsonReader(new FileReader(classesAndBreakpoints))) {
             Gson gson = new Gson();
             return gson.fromJson(jr, new TypeToken<List<FileAndBreakpoint>>() {}.getType());
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    private List<MethodForExitEvent> parseMethodsForExitEvent(File methodsForExitEvent) {
+        if (methodsForExitEvent == null) {
+            return null;
+        }
+        try (JsonReader jr = new JsonReader(new FileReader(methodsForExitEvent))) {
+            Gson gson = new Gson();
+            return gson.fromJson(jr, new TypeToken<List<MethodForExitEvent>>() {}.getType());
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage());
         }

--- a/src/main/java/se/kth/debug/struct/MethodForExitEvent.java
+++ b/src/main/java/se/kth/debug/struct/MethodForExitEvent.java
@@ -1,0 +1,37 @@
+package se.kth.debug.struct;
+
+public class MethodForExitEvent {
+    private final String name;
+    private final String className;
+
+    public MethodForExitEvent(String name, String className) {
+        this.name = name;
+        this.className = className;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        MethodForExitEvent other = (MethodForExitEvent) obj;
+        return name.equals(other.name) && className.equals(other.className);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + name.hashCode();
+        result = prime * result + className.hashCode();
+        return result;
+    }
+}

--- a/src/test/java/CollectorAPITest.java
+++ b/src/test/java/CollectorAPITest.java
@@ -535,4 +535,36 @@ public class CollectorAPITest {
         // assert
         assertThat(eventProcessor.getReturnValues().size(), equalTo(8));
     }
+
+    @Test
+    void returnDataShouldBeCollected_evenIfThereAreNoBreakpoints()
+            throws FileNotFoundException, AbsentInformationException {
+        // arrange
+        String[] classpath =
+                TestHelper.getMavenClasspathFromBuildDirectory(
+                        TestHelper.PATH_TO_SAMPLE_MAVEN_PROJECT.resolve("with-debug"));
+        String[] tests = new String[] {"foo.RecordMyReturnButWithoutBreakpointsTest::abba"};
+        File classesAndBreakpoints =
+                TestHelper.PATH_TO_INPUT
+                        .resolve("return-value-without-breakpoints")
+                        .resolve("input.txt")
+                        .toFile();
+        File methodsForExitEvent =
+                TestHelper.PATH_TO_INPUT
+                        .resolve("return-value-without-breakpoints")
+                        .resolve("methods.json")
+                        .toFile();
+
+        // act
+        EventProcessor eventProcessor =
+                Collector.invoke(
+                        classpath,
+                        tests,
+                        classesAndBreakpoints,
+                        methodsForExitEvent,
+                        TestHelper.getDefaultOptions().setSkipBreakpointValues(true));
+
+        // assert
+        assertThat(eventProcessor.getReturnValues().size(), equalTo(1));
+    }
 }

--- a/src/test/java/MatchedLineFinderTest.java
+++ b/src/test/java/MatchedLineFinderTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -49,13 +49,14 @@ class MatchedLineFinderTest {
         if (IGNORE_TESTS.contains(sources.dir)) {
             assumeTrue(false);
         }
-        Pair<String, String> inputsForCollectorSahab =
+        Triple<String, String, String> inputsForCollectorSahab =
                 MatchedLineFinder.invoke(sources.left, sources.right);
         assertInputsAreAsExpected(inputsForCollectorSahab, sources.expected);
     }
 
     private void assertInputsAreAsExpected(
-            Pair<String, String> input, Path dirContainingExpectedFiles) throws IOException {
+            Triple<String, String, String> input, Path dirContainingExpectedFiles)
+            throws IOException {
         List<FileAndBreakpoint> actualBreakpointLeft =
                 deserialiseFileAndBreakpoint(input.getLeft());
         List<FileAndBreakpoint> actualBreakpointRight =

--- a/src/test/resources/sample-maven-project/src/main/java/foo/RecordMyReturnButWithoutBreakpoints.java
+++ b/src/test/resources/sample-maven-project/src/main/java/foo/RecordMyReturnButWithoutBreakpoints.java
@@ -1,0 +1,7 @@
+package foo;
+
+public class RecordMyReturnButWithoutBreakpoints {
+    public static String gimmegimmegimme() {
+        return "a man after midnight";
+    }
+}

--- a/src/test/resources/sample-maven-project/src/test/java/foo/RecordMyReturnButWithoutBreakpointsTest.java
+++ b/src/test/resources/sample-maven-project/src/test/java/foo/RecordMyReturnButWithoutBreakpointsTest.java
@@ -1,0 +1,14 @@
+package foo;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import foo.RecordMyReturnButWithoutBreakpoints;
+
+public class RecordMyReturnButWithoutBreakpointsTest {
+    @Test
+    void abba() {
+        String x = RecordMyReturnButWithoutBreakpoints.gimmegimmegimme();
+        assertFalse(x.isEmpty());
+    }
+}

--- a/src/test/resources/sample-maven-project/src/test/resources/inputs/return-value-without-breakpoints/input.txt
+++ b/src/test/resources/sample-maven-project/src/test/resources/inputs/return-value-without-breakpoints/input.txt
@@ -1,0 +1,6 @@
+[
+  {
+    "fileName": "foo.RecordMyReturnButWithoutBreakpoints",
+    "breakpoints": []
+  }
+]

--- a/src/test/resources/sample-maven-project/src/test/resources/inputs/return-value-without-breakpoints/methods.json
+++ b/src/test/resources/sample-maven-project/src/test/resources/inputs/return-value-without-breakpoints/methods.json
@@ -1,0 +1,6 @@
+[
+  {
+    "className": "foo.RecordMyReturnButWithoutBreakpoints",
+    "name": "gimmegimmegimme"
+  }
+]


### PR DESCRIPTION
Some patches like [this](https://github.com/khaes-kth/drr-execdiff/commit/1827393f855be5fa4c173efcca1805712236770d) have no matched lines, but we can still analyse the difference in their return values. The changes in the PR pass their names so that the trace collector can record their return values.