### PR TITLE
chore: handle multi-modular maven projects

### DIFF
--- a/scripts/bribe-sahab.py
+++ b/scripts/bribe-sahab.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+from glob import glob
 
 from revision import REVISION
 from compile_target import compile
@@ -50,11 +51,13 @@ def _get_or_create_directory_for_creating_output_files(ref):
   return output_directory
 
 def _run_collector_sahab(project, tests, revision, ref):
-  project_dependencies = [
-    os.path.join(project, revision.value.get_output_directory(), 'classes'),
-    os.path.join(project, revision.value.get_output_directory(), 'test-classes'),
-    os.path.join(project, revision.value.get_output_directory(), 'dependency'),
-  ]
+  all_targets = glob(f"{project}/**/{revision.value.get_output_directory()}/", recursive=True)
+  project_dependencies = []
+  for build_dir in all_targets:
+    project_dependencies.append(os.path.join(build_dir, 'classes'))
+    project_dependencies.append(os.path.join(build_dir, 'test-classes'))
+    project_dependencies.append(os.path.join(build_dir, 'dependency'))
+
   test_methods = " ".join(tests)
   output_directory = _get_or_create_directory_for_creating_output_files(ref)
   collector_sahab_output = os.path.join(output_directory, f"{revision.name.lower()}.json")
@@ -68,6 +71,7 @@ def _run_collector_sahab(project, tests, revision, ref):
     f"-o {collector_sahab_output} "
     f"-m methods.json"
   )
+  print(cmd)
 
   subprocess.run(cmd, shell=True)
 

--- a/scripts/command.py
+++ b/scripts/command.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from glob import glob
 
 class Command:
 
@@ -37,12 +38,18 @@ class Command:
     ], cwd=self.cwd)
 
   def rename(self, renamed_directory):
-    subprocess.run([
-      "mv",
-      "target",
-      renamed_directory,
-    ], cwd=self.cwd)
+    all_targets = glob(f"{self.cwd}/**/target/", recursive=True)
+    for build_dir in all_targets:
+      subprocess.run([
+        "mv",
+        build_dir,
+        os.path.dirname(os.path.dirname(build_dir)) + f"/{renamed_directory}",
+      ], cwd=self.cwd)
 
+  def clean(self, revision):
+    all_targets = glob(f"{self.cwd}/**/{revision.value.get_output_directory()}/", recursive=True)
+    for build_dir in all_targets:
+      self.remove(build_dir)
 
   def _replace_plugin_properties(self):
     # We replace them to empty strings because we are using user properties

--- a/scripts/compile_target.py
+++ b/scripts/compile_target.py
@@ -21,7 +21,7 @@ def compile(project, commit, revision):
   
   driver = Command(project)
   driver.remove(os.path.join(os.getcwd(), revision.value.get_input_file()))
-  driver.remove(revision.value.get_output_directory())
+  driver.clean(revision)
 
   driver.git_checkout(commit)
 


### PR DESCRIPTION
We assumed that the `target` directory shall always be at the root of the project. However, that is not true for multi-modular projects. The changes look for all the nested `target` folders and add them to the classpath.