### PR TITLE
chore: build classpath instead of copying dependencies

### DIFF
--- a/scripts/bribe-sahab.py
+++ b/scripts/bribe-sahab.py
@@ -57,7 +57,9 @@ def _run_collector_sahab(project, tests, revision, ref):
   for build_dir in all_targets:
     project_dependencies.append(os.path.join(build_dir, 'classes'))
     project_dependencies.append(os.path.join(build_dir, 'test-classes'))
-    project_dependencies.append(os.path.join(build_dir, 'dependency'))
+    with open(os.path.join(build_dir, 'cp.txt')) as cp:
+      classpath = cp.read().strip()
+      project_dependencies.extend(classpath.split(':'))
 
   test_methods = " ".join(tests)
   output_directory = _get_or_create_directory_for_creating_output_files(ref)

--- a/scripts/command.py
+++ b/scripts/command.py
@@ -22,10 +22,11 @@ class Command:
       "-Dmaven.compiler.debuglevel=lines,vars,source",
     ], cwd=self.cwd)
 
-  def mvn_copy_dependencies(self):
+  def mvn_build_classpath(self):
     subprocess.run([
       "mvn",
-      "dependency:copy-dependencies"
+      "dependency:build-classpath",
+      "-Dmdep.outputFile=target/cp.txt"
     ], cwd=self.cwd)
 
   def remove(self, dir):

--- a/scripts/compile_target.py
+++ b/scripts/compile_target.py
@@ -26,7 +26,7 @@ def compile(project, commit, revision):
   driver.git_checkout(commit)
 
   driver.mvn_test_compile()
-  driver.mvn_copy_dependencies()
+  driver.mvn_build_classpath()
 
   driver.rename(revision.value.get_output_directory())
 


### PR DESCRIPTION
Passing the dependencies to `-p` parameter worked better instead of using the maven copy dependencies plugin. I just need to check if it works for multi-module projects as well. EDIT: It works!