### PR TITLE
chore: run all JUnit tests in a single container

### DIFF
--- a/src/main/java/se/kth/debug/JUnitTestRunner.java
+++ b/src/main/java/se/kth/debug/JUnitTestRunner.java
@@ -4,53 +4,52 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 
 import java.io.PrintWriter;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.*;
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.console.tasks.ConsoleTestExecutor;
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.MethodSelector;
 
 public class JUnitTestRunner {
     public static void main(String... args) {
-        String[] tests = args[0].split(" ");
-        for (final String test : tests) {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            Callable<Object> task =
-                    () -> {
-                        if (test.contains("::")) {
-                            runTestMethod(test);
-                        } else {
-                            runTestClass(test);
-                        }
-                        return 0;
-                    };
-            Future<Object> future = executor.submit(task);
-            try {
-                executor.shutdown();
-                future.get(4, TimeUnit.MINUTES);
-            } catch (Exception ex) {
-                // handle other exceptions
-                ex.printStackTrace();
-            } finally {
-                future.cancel(true);
-            }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Callable<Object> task =
+                () -> {
+                    runTests(args[0].split(" "));
+                    return 0;
+                };
+        Future<Object> future = executor.submit(task);
+        try {
+            executor.shutdown();
+            future.get(4, TimeUnit.MINUTES);
+        } catch (Exception ex) {
+            // handle other exceptions
+            ex.printStackTrace();
+        } finally {
+            future.cancel(true);
         }
     }
 
-    private static void runTestMethod(String test) throws Exception {
-        String[] classAndMethod = test.split("::");
-        String clazz = classAndMethod[0];
-        String method = classAndMethod[1];
+    private static void runTests(String... tests) throws Exception {
+        Set<MethodSelector> methods = new HashSet<>();
+        Set<ClassSelector> classes = new HashSet<>();
+        for (final String test : tests) {
+            if (test.contains("::")) {
+                String[] classAndMethod = test.split("::");
+                String clazz = classAndMethod[0];
+                String method = classAndMethod[1];
 
+                methods.add(selectMethod(clazz + "#" + method));
+            } else {
+                classes.add(selectClass(test));
+            }
+        }
         CommandLineOptions options = new CommandLineOptions();
-        options.setSelectedMethods(Collections.singletonList(selectMethod(clazz + "#" + method)));
-        options.setFailIfNoTests(true);
-        options.setAnsiColorOutputDisabled(true);
-        new ConsoleTestExecutor(options).execute(new PrintWriter(System.out));
-    }
-
-    private static void runTestClass(String test) throws Exception {
-        CommandLineOptions options = new CommandLineOptions();
-        options.setSelectedClasses(Collections.singletonList(selectClass(test)));
+        options.setSelectedMethods(new ArrayList<>(methods));
+        options.setSelectedClasses(new ArrayList<>(classes));
         options.setFailIfNoTests(true);
         options.setAnsiColorOutputDisabled(true);
         new ConsoleTestExecutor(options).execute(new PrintWriter(System.out));

--- a/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/mix-of-method-and-class.regex
+++ b/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/mix-of-method-and-class.regex
@@ -1,43 +1,24 @@
 ╷
 ├─ JUnit Jupiter ✔
+│  └─ JUnit5Test ✔
+│     ├─ test_add\(\) ✔
+│     └─ test_subtract\(\) ✔
 ├─ JUnit Vintage ✔
 │  └─ JUnit4Test ✔
 │     └─ test_concat ✔
 └─ JUnit Platform Suite ✔
 
 Test run finished after [\d]+ ms
-\[         4 containers found      \]
+\[         5 containers found      \]
 \[         0 containers skipped    \]
-\[         4 containers started    \]
+\[         5 containers started    \]
 \[         0 containers aborted    \]
-\[         4 containers successful \]
+\[         5 containers successful \]
 \[         0 containers failed     \]
-\[         1 tests found           \]
+\[         3 tests found           \]
 \[         0 tests skipped         \]
-\[         1 tests started         \]
+\[         3 tests started         \]
 \[         0 tests aborted         \]
-\[         1 tests successful      \]
-\[         0 tests failed          \]
-
-╷
-├─ JUnit Jupiter ✔
-│  └─ JUnit5Test ✔
-│     ├─ test_add\(\) ✔
-│     └─ test_subtract\(\) ✔
-├─ JUnit Vintage ✔
-└─ JUnit Platform Suite ✔
-
-Test run finished after [\d]+ ms
-\[         4 containers found      \]
-\[         0 containers skipped    \]
-\[         4 containers started    \]
-\[         0 containers aborted    \]
-\[         4 containers successful \]
-\[         0 containers failed     \]
-\[         2 tests found           \]
-\[         0 tests skipped         \]
-\[         2 tests started         \]
-\[         0 tests aborted         \]
-\[         2 tests successful      \]
+\[         3 tests successful      \]
 \[         0 tests failed          \]
 

--- a/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/run-4-and-5.regex
+++ b/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/run-4-and-5.regex
@@ -1,5 +1,8 @@
 ╷
 ├─ JUnit Jupiter ✔
+│  └─ JUnit5Test ✔
+│     ├─ test_add\(\) ✔
+│     └─ test_subtract\(\) ✔
 ├─ JUnit Vintage ✔
 │  └─ JUnit4Test ✔
 │     ├─ test_concat ✔
@@ -7,38 +10,16 @@
 └─ JUnit Platform Suite ✔
 
 Test run finished after [\d]+ ms
-\[         4 containers found      \]
+\[         5 containers found      \]
 \[         0 containers skipped    \]
-\[         4 containers started    \]
+\[         5 containers started    \]
 \[         0 containers aborted    \]
-\[         4 containers successful \]
+\[         5 containers successful \]
 \[         0 containers failed     \]
-\[         2 tests found           \]
+\[         4 tests found           \]
 \[         0 tests skipped         \]
-\[         2 tests started         \]
+\[         4 tests started         \]
 \[         0 tests aborted         \]
-\[         2 tests successful      \]
-\[         0 tests failed          \]
-
-╷
-├─ JUnit Jupiter ✔
-│  └─ JUnit5Test ✔
-│     ├─ test_add\(\) ✔
-│     └─ test_subtract\(\) ✔
-├─ JUnit Vintage ✔
-└─ JUnit Platform Suite ✔
-
-Test run finished after [\d]+ ms
-\[         4 containers found      \]
-\[         0 containers skipped    \]
-\[         4 containers started    \]
-\[         0 containers aborted    \]
-\[         4 containers successful \]
-\[         0 containers failed     \]
-\[         2 tests found           \]
-\[         0 tests skipped         \]
-\[         2 tests started         \]
-\[         0 tests aborted         \]
-\[         2 tests successful      \]
+\[         4 tests successful      \]
 \[         0 tests failed          \]
 


### PR DESCRIPTION
Initially, a new JUnit container was spawned for each test. These changes partse the test argument and pass it to the JUnit container so that only one container is spawned.