### PR TITLE
tests: load classpath from `cp.txt`

### DIFF
--- a/src/test/java/TestHelper.java
+++ b/src/test/java/TestHelper.java
@@ -1,8 +1,12 @@
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import se.kth.debug.CollectorOptions;
 
 public class TestHelper {
@@ -26,11 +30,18 @@ public class TestHelper {
             throw new FileNotFoundException(buildDirectory + " does not exist");
         }
         List<String> classpath =
-                List.of(
-                        buildDirectory.resolve("classes").toString(),
-                        buildDirectory.resolve("test-classes").toString(),
-                        buildDirectory.resolve("dependency").toString());
-        return classpath.toArray(new String[] {});
+                new ArrayList<>(
+                        List.of(
+                                buildDirectory.resolve("classes").toString(),
+                                buildDirectory.resolve("test-classes").toString()));
+        try {
+            String additionalClasspath = Files.readString(buildDirectory.resolve("cp.txt"));
+            classpath.addAll(
+                    Arrays.stream(additionalClasspath.split(":")).collect(Collectors.toList()));
+            return classpath.toArray(new String[] {});
+        } catch (IOException e) {
+            throw new RuntimeException("Classpath of " + buildDirectory + " could not be read.");
+        }
     }
 
     public static CollectorOptions getDefaultOptions() {

--- a/src/test/resources/build.sh
+++ b/src/test/resources/build.sh
@@ -2,5 +2,5 @@
 
 build () {
   mvn test-compile -Dmaven.compiler.debug="$1" -DbuildDirectory="$2"
-  mvn dependency:copy-dependencies -DbuildDirectory="$2"
+  mvn dependency:build-classpath -Dmdep.outputFile="$2/cp.txt"
 }


### PR DESCRIPTION
This was implemented in https://github.com/algomaster99/collector-sahab/pull/96, however, the tests were still following the old method so the changes update that.