### PR TITLE
chrore: Use config file for JAR and output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ It does three things:
 2. Find the matched lines
 3. Run collector-sahab over the project to collect runtime context
 
+Before you run `bribe-sahab`, populate config file by following the steps below:
+1. ```
+   cp config_stencil.json config.json
+   ```
+2. Fill `config.json` accordingly. See example:
+   ```json
+   {
+     "collectorJar": "/home/assert/Desktop/assert-achievements/collector-sahab/target/collector-sahab-0.0.1-SNAPSHOT-jar-with-dependencies.jar",
+     "outputDirectory": "/home/assert/Desktop/experiments/drr-as-pr/"
+   }
+   ```
+
+
 ```bash
 usage: Bribe sahab [-h] -p PROJECT -l LEFT -r RIGHT -c CLASS_FILENAME -t TESTS [TESTS ...]
 

--- a/scripts/bribe-sahab.py
+++ b/scripts/bribe-sahab.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import shlex
 import subprocess
@@ -7,8 +8,10 @@ from glob import glob
 from revision import REVISION
 from compile_target import compile
 
-COLLECTOR_JAR = "/home/assert/Desktop/assert-achievements/collector-sahab/target/collector-sahab-0.0.1-SNAPSHOT-jar-with-dependencies.jar"
-OUTPUT_DIRECTORY = "/home/assert/Desktop/experiments/drr-as-pr/"
+CONFIG = json.load(open(os.path.join(os.path.dirname(__file__), 'config.json')))
+
+COLLECTOR_JAR = CONFIG.get('collectorJar', None)
+OUTPUT_DIRECTORY = CONFIG.get('outputDirectory', '')
 
 class VerifyDirectory(argparse.Action):
   def __call__(self, parser, namespace, directory, option_string=None):

--- a/scripts/config_stencil.json
+++ b/scripts/config_stencil.json
@@ -1,0 +1,4 @@
+{
+  "collectorJar": "<Path to JAR of collector sahab>",
+  "outputDirectory": "<Path to trace output>"
+}


### PR DESCRIPTION
@khaes-kth No need to edit the paths to the jar file and output directory. You can have a `config.json` instead.