### PR TITLE
chore: make spotless compatible with maven 3.8.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Check maven version
-        run: mvn -version
+      - name: Style check using spotless
+        run: 'mvn spotless:check'
+      - name: Run test phase
+        run: |
+          ./src/test/resources/sample-maven-project/with-debug.sh
+          ./src/test/resources/sample-maven-project-cannot-be-debugged/without-debug.sh
+          mvn test
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,5 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Style check using spotless
-        run: 'mvn spotless:check'
-      - name: Run test phase
-        run: |
-          ./src/test/resources/sample-maven-project/with-debug.sh
-          ./src/test/resources/sample-maven-project-cannot-be-debugged/without-debug.sh
-          mvn test
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1
+      - name: Check maven version
+        run: mvn -version

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>2.22.7</version>
                 <configuration>
                     <java>
                         <includes>
@@ -63,7 +63,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.9</version>
+                            <version>1.15.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                     </java>


### PR DESCRIPTION
Spotless' `apply` goal was breaking on the project when ran with `maven v3.8.6`. Upgrading spotless to `1.15.0` and `spotless-maven-plugin` to `2.22.7` worked.