### PR TITLE
tests: prove JUnit does not care about 'Test' prefix or suffix

### DIFF
--- a/src/test/java/JUnitTestRunnerTest.java
+++ b/src/test/java/JUnitTestRunnerTest.java
@@ -67,4 +67,13 @@ class JUnitTestRunnerTest {
 
         assertThat(getActualLogs(tests), matchesPattern(Files.readString(expectedLogRegex)));
     }
+
+    @Test
+    void main_canDiscoverTest_withoutItsNameStartingOrEndingInTest()
+            throws IOException, InterruptedException, ClassNotFoundException {
+        String tests = "foo.junit.IDoNotFollowConventions::sum";
+        Path expectedLogRegex = PATH_TO_JUNIT_LOGS.resolve("disobey-conventions.regex");
+
+        assertThat(getActualLogs(tests), matchesPattern(Files.readString(expectedLogRegex)));
+    }
 }

--- a/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/java/foo/junit/IDoNotFollowConventions.java
+++ b/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/java/foo/junit/IDoNotFollowConventions.java
@@ -1,0 +1,12 @@
+package foo.junit;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class IDoNotFollowConventions {
+    @Test
+    public void sum() {
+        assertEquals(5, 2+2);
+    }
+}

--- a/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/disobey-conventions.regex
+++ b/src/test/resources/sample-maven-project-cannot-be-debugged/src/test/resources/junit-test-runner-logs/disobey-conventions.regex
@@ -1,0 +1,37 @@
+╷
+├─ JUnit Jupiter ✔
+│  └─ IDoNotFollowConventions ✔
+│     └─ sum\(\) ✘ expected:<5> but was:<4>
+├─ JUnit Vintage ✔
+└─ JUnit Platform Suite ✔
+
+Failures \(1\):
+  JUnit Jupiter:IDoNotFollowConventions:sum\(\)
+    MethodSource \[className = 'foo\.junit\.IDoNotFollowConventions', methodName = 'sum', methodParameterTypes = ''\]
+    => java\.lang\.AssertionError: expected:<5> but was:<4>
+       org\.junit\.Assert\.fail\(Assert\.java:89\)
+       org\.junit\.Assert\.failNotEquals\(Assert\.java:835\)
+       org\.junit\.Assert\.assertEquals\(Assert\.java:647\)
+       org\.junit\.Assert\.assertEquals\(Assert\.java:633\)
+       foo\.junit\.IDoNotFollowConventions\.sum\(IDoNotFollowConventions\.java:10\)
+       java\.base/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke0\(Native Method\)
+       java\.base/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke\(NativeMethodAccessorImpl\.java:62\)
+       java\.base/jdk\.internal\.reflect\.DelegatingMethodAccessorImpl\.invoke\(DelegatingMethodAccessorImpl\.java:43\)
+       java\.base/java\.lang\.reflect\.Method\.invoke\(Method\.java:566\)
+       org\.junit\.platform\.commons\.util\.ReflectionUtils\.invokeMethod\(ReflectionUtils\.java:727\)
+       \[\.\.\.\]
+
+Test run finished after [\d]+ ms
+\[         4 containers found      \]
+\[         0 containers skipped    \]
+\[         4 containers started    \]
+\[         0 containers aborted    \]
+\[         4 containers successful \]
+\[         0 containers failed     \]
+\[         1 tests found           \]
+\[         0 tests skipped         \]
+\[         1 tests started         \]
+\[         0 tests aborted         \]
+\[         0 tests successful      \]
+\[         1 tests failed          \]
+


### PR DESCRIPTION
@monperrus I added a test case that proves JUnit will discover the test even if it does not have `Test` in the prefix or suffix in the test class or method.